### PR TITLE
fix: don't error when there are no files to copy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export async function beforeBuild(options: BuilderOptions) {
   return new Promise((resolve, reject) => {
     copyfiles(
       ["src/**/*.module.css", "pkg/dist-src"],
-      { up: 1, follow: true, error: true },
+      { up: 1, follow: true },
       (err, res) => {
         if (err) {
           reject(err)


### PR DESCRIPTION
when a pkg built with this does not have any `module.css` files, it currently errors (which is a bit overkill)